### PR TITLE
es 1.4.0 needs index.version.created in its settings, added parameter to...

### DIFF
--- a/src/main/java/at/molindo/esi4j/core/impl/DefaultIndex.java
+++ b/src/main/java/at/molindo/esi4j/core/impl/DefaultIndex.java
@@ -176,7 +176,7 @@ public class DefaultIndex extends AbstractIndex implements InternalIndex {
 					public ListenableActionFuture<PutMappingResponse> execute(Client client, String indexName) {
 						PutMappingRequestBuilder request = client.admin().indices().preparePutMapping(indexName);
 						request.setType(typeMapping.getTypeAlias());
-						typeMapping.getMappingSource().setSource(request);
+						typeMapping.getMappingSource(getSettings()).setSource(request);
 						return request.execute();
 					}
 

--- a/src/main/java/at/molindo/esi4j/mapping/TypeMapping.java
+++ b/src/main/java/at/molindo/esi4j/mapping/TypeMapping.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.SearchHit;
 
@@ -120,7 +121,7 @@ public abstract class TypeMapping {
 	/**
 	 * @return a new {@link MappingSource} for this type
 	 */
-	public abstract MappingSource getMappingSource();
+	public abstract MappingSource getMappingSource(Settings indexSettings);
 
 	/**
 	 * @return a new {@link ObjectSource} for this object

--- a/src/main/java/at/molindo/esi4j/mapping/impl/GenericTypeMapping.java
+++ b/src/main/java/at/molindo/esi4j/mapping/impl/GenericTypeMapping.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -74,7 +74,7 @@ public abstract class GenericTypeMapping<Type, Id> extends TypeMapping {
 	}
 
 	@Override
-	public final MappingSource getMappingSource() {
+	public final MappingSource getMappingSource(final Settings settings) {
 		try {
 			if (_mapping == null || isDynamicMapping()) {
 				Builder mapperBuilder = new RootObjectMapper.Builder(getTypeAlias());
@@ -84,8 +84,9 @@ public abstract class GenericTypeMapping<Type, Id> extends TypeMapping {
 				XContentBuilder contentBuilder = JsonXContent.contentBuilder();
 
 				contentBuilder.startObject();
-				mapperBuilder.build(new BuilderContext(ImmutableSettings.EMPTY, new ContentPath())).toXContent(
-						contentBuilder, EMPTY_PARAMS, new ToXContent() {
+
+				mapperBuilder.build(new BuilderContext(settings, new ContentPath())).toXContent(contentBuilder,
+						EMPTY_PARAMS, new ToXContent() {
 
 							@Override
 							public XContentBuilder toXContent(XContentBuilder builder, Params params)


### PR DESCRIPTION
... pass settings to typemapping. 

v1.4.0 of ES requires [index.version.created to be set](https://github.com/elasticsearch/elasticsearch/pull/8018) in the settings. I therefore changed the method signature to require a settings param, since the BuilderContext in GenericTypeMapping used to pass empty settings to the check (before 1.3 it passed null) which always led to an exception on startup even if esi4j got initalised _with_ the required setting.
